### PR TITLE
Docear No Longer Works on Ubuntu 18.04

### DIFF
--- a/Jabref_Beta_2_7_Docear/build.number
+++ b/Jabref_Beta_2_7_Docear/build.number
@@ -1,3 +1,3 @@
 #Build Number for ANT. Do not edit!
-#Fri Jun 29 18:17:05 EDT 2018
-build.number=90
+#Fri Jun 29 22:11:40 EDT 2018
+build.number=96

--- a/Jabref_Beta_2_7_Docear/build.number
+++ b/Jabref_Beta_2_7_Docear/build.number
@@ -1,3 +1,3 @@
 #Build Number for ANT. Do not edit!
-#Fri Jan 15 10:01:48 CST 2016
-build.number=88
+#Fri Jun 29 18:17:05 EDT 2018
+build.number=90

--- a/Jabref_Beta_2_7_Docear/src/resource/build.properties
+++ b/Jabref_Beta_2_7_Docear/src/resource/build.properties
@@ -1,3 +1,3 @@
 builddate=June 29 2018
-build=89
+build=95
 version=2.7.1

--- a/Jabref_Beta_2_7_Docear/src/resource/build.properties
+++ b/Jabref_Beta_2_7_Docear/src/resource/build.properties
@@ -1,3 +1,3 @@
-builddate=January 15 2016
-build=87
+builddate=June 29 2018
+build=89
 version=2.7.1

--- a/build.xml
+++ b/build.xml
@@ -1,14 +1,17 @@
-<project name="GlobalFreeplane" default="dist" basedir=".">
+<project name="Docear" default="dist" basedir=".">
 
 	<target name="build">
-		<ant antfile="freeplane_framework/ant/build.xml"  target="build"
-			inheritAll="false" />
+	        <ant antfile="Jabref_Beta_2_7_Docear/build.xml" target="build" inheritAll="false" />
+	        <ant antfile="freeplane/ant/build.xml" target="build" inheritAll="false" />
+	        <ant antfile="docear_framework/ant/build.xml" target="build" inheritAll="false" />
 	</target>
 
 	<target name="dist">
-		<ant antfile="freeplane_framework/ant/build.xml"  target="dist"
-			inheritAll="false" />
+	        <ant antfile="Jabref_Beta_2_7_Docear/build.xml" target="dist" inheritAll="false" />
+	        <ant antfile="freeplane/ant/build.xml" target="dist" inheritAll="false" />
+	        <ant antfile="docear_framework/ant/build.xml" target="dist" inheritAll="false" />
 	</target>
+
 	<target name="format-translation">
 		<ant antfile="JOrtho_0.4_freeplane/build.xml"  target="format-translation"
 			inheritAll="false" />
@@ -17,14 +20,13 @@
 	</target>
 
 	<target name="clean">
-		<ant antfile="freeplane_framework/ant/build.xml"  target="clean"
-			inheritAll="false" />
+	        <ant antfile="Jabref_Beta_2_7_Docear/build.xml" target="clean" inheritAll="false" />
+	        <ant antfile="freeplane/ant/build.xml" target="clean" inheritAll="false" />
+	        <ant antfile="docear_framework/ant/build.xml" target="clean" inheritAll="false" />
 
-	<ant antfile="freeplane_ant/build.xml" target="clean"
-			inheritAll="false" />
+		<ant antfile="freeplane_ant/build.xml" target="clean" inheritAll="false" />
 
-	<ant antfile="JOrtho_0.4_freeplane/build.xml" target="clean"
-		inheritAll="false" />
+		<ant antfile="JOrtho_0.4_freeplane/build.xml" target="clean" inheritAll="false" />
 	</target>
 
 	<target name="cleandist" depends="clean, dist">

--- a/docear_framework/docear.version.properties
+++ b/docear_framework/docear.version.properties
@@ -1,7 +1,7 @@
-#Thu, 14 Jan 2016 22:00:13 -0600
+#Fri, 29 Jun 2018 18:16:46 -0400
 docear.build.version.major=1
 docear.build.version.middle=2
 docear.build.version.minor=0
 docear.build.status.number=24
 
-docear.build.date=01/14/2016
+docear.build.date=06/29/2018

--- a/docear_framework/docear.version.properties
+++ b/docear_framework/docear.version.properties
@@ -1,4 +1,4 @@
-#Fri, 29 Jun 2018 18:16:46 -0400
+#Fri, 29 Jun 2018 22:11:31 -0400
 docear.build.version.major=1
 docear.build.version.middle=2
 docear.build.version.minor=0

--- a/docear_plugin_core/resources/build.number
+++ b/docear_plugin_core/resources/build.number
@@ -1,3 +1,3 @@
 #Build Number for ANT. Do not edit!
-#Thu Jan 14 22:00:13 CST 2016
-build.number=240
+#Fri Jun 29 18:16:46 EDT 2018
+build.number=241

--- a/docear_plugin_core/resources/build.number
+++ b/docear_plugin_core/resources/build.number
@@ -1,3 +1,3 @@
 #Build Number for ANT. Do not edit!
-#Fri Jun 29 18:16:46 EDT 2018
-build.number=241
+#Fri Jun 29 22:11:31 EDT 2018
+build.number=243

--- a/docear_plugin_core/resources/version.properties
+++ b/docear_plugin_core/resources/version.properties
@@ -1,7 +1,7 @@
-#Thu, 14 Jan 2016 22:00:13 -0600
-docear_version=1.2.1
+#Fri, 29 Jun 2018 18:16:46 -0400
+docear_version=1.2.0
 docear_version_status=devel
 docear_version_status_number=24
 homepage_url=http\://docear.org
 
-build_date=01/14/2016
+build_date=06/29/2018

--- a/docear_plugin_core/resources/version.properties
+++ b/docear_plugin_core/resources/version.properties
@@ -1,4 +1,4 @@
-#Fri, 29 Jun 2018 18:16:46 -0400
+#Fri, 29 Jun 2018 22:11:31 -0400
 docear_version=1.2.0
 docear_version_status=devel
 docear_version_status_number=24

--- a/freeplane/src/org/freeplane/core/ui/MenuBuilder.java
+++ b/freeplane/src/org/freeplane/core/ui/MenuBuilder.java
@@ -61,6 +61,7 @@ import javax.swing.SwingUtilities;
 import javax.swing.event.PopupMenuEvent;
 import javax.swing.event.PopupMenuListener;
 import javax.swing.tree.DefaultMutableTreeNode;
+import javax.swing.tree.TreeNode;
 
 import org.freeplane.core.io.IElementHandler;
 import org.freeplane.core.io.ReadManager;
@@ -889,7 +890,7 @@ public class MenuBuilder extends UIBuilder implements IKeyStrokeProcessor {
 		if (userObject instanceof JMenuItem && !(userObject instanceof JMenu)) {
 			setAccelerator((Node) node, null);
 		}
-		for (final Enumeration<Object> children = node.children(); children.hasMoreElements();) {
+		for (final Enumeration<TreeNode> children = node.children(); children.hasMoreElements();) {
 			removeAccelerators((DefaultMutableTreeNode) children.nextElement());
 		}
 	}


### PR DESCRIPTION
When I upgraded to Ubuntu 18.04, Docear stopped working. I don't
entirely understand the reason, but it was using Object instead of a
more specific type, and this was causing a runtime error.